### PR TITLE
Replace Users type with interface

### DIFF
--- a/apps/app/src/app/users/types/users.types.ts
+++ b/apps/app/src/app/users/types/users.types.ts
@@ -1,4 +1,4 @@
-export type Users = Array<User>;
+export interface Users extends Array<User> {};
 
 export interface User {
   name: string;


### PR DESCRIPTION
This PR resolves the the following wallaby error:
```
​​Uncaught ReferenceError: users_types_1 is not defined​​ at ​apps/app/src/app/users/users.component.ts:9​
```